### PR TITLE
fix: use Log::EntriesChecker in specs

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,6 +1,6 @@
 name: log_helper
-version: 1.0.2
-crystal: 0.35.0
+version: 1.0.3
+crystal: ">= 0.35"
 
 authors:
   - Caspian Baska <caspian@place.tech>

--- a/spec/log_helper_spec.cr
+++ b/spec/log_helper_spec.cr
@@ -1,67 +1,51 @@
 require "./spec_helper"
 
-describe Log do
-  output = IO::Memory.new
-  backend = Log::IOBackend.new(output)
-  backend.formatter = Log::Formatter.new do |entry, io|
-    io << entry.message
-    io << ": "
-    entry.context.each do |k, v|
-      io << k << "=" << v
-    end
-    entry.data.each do |k, v|
-      io << k << "=" << v
+Log.setup(:none)
+
+def expect_log_data(message, data)
+  Log.capture do |checker|
+    yield
+    checker.next(::Log::Severity::Fatal, message).entry.tap do |e|
+      e.message.should eq message
+      e.data.should eq ::Log::Metadata.build(data)
     end
   end
+end
 
-  log = Log.for("*", level: :trace)
-
-  Spec.before_suite do
-    Log.builder.clear
-    log.backend = backend
-  end
-
-  Spec.before_each { output.clear }
-
+describe ::Log do
   it "sets entry data via blocks that return a NamedTuple" do
-    log.fatal { {hello: "world", message: "okay"} }
-    message, _, rest = output.to_s.chomp.partition(": ")
-    message.should eq "okay"
-    rest.should eq "hello=world"
+    expect_log_data("okay", {:hello => "world"}) do
+      Log.fatal { {hello: "world", message: "okay"} }
+    end
   end
 
   it "sets entry data via blocks that return a Hash" do
-    log.fatal { {:hello => "world", :message => "okay"} }
-    message, _, rest = output.to_s.chomp.partition(": ")
-    message.should eq "okay"
-    rest.should eq "hello=world"
+    expect_log_data("okay", {:hello => "world"}) do
+      Log.fatal { {:hello => "world", :message => "okay"} }
+    end
   end
 
   it "works with missing `message` within a NamedTuple" do
-    log.fatal { {hello: "world"} }
-    message, _, rest = output.to_s.chomp.partition(": ")
-    message.should eq ""
-    rest.should eq "hello=world"
+    expect_log_data("", {:hello => "world"}) do
+      Log.fatal { {hello: "world"} }
+    end
   end
 
   it "works with missing `message` within a Hash" do
-    log.fatal { {:hello => "world"} }
-    message, _, rest = output.to_s.chomp.partition(": ")
-    message.should eq ""
-    rest.should eq "hello=world"
+    expect_log_data("", {:hello => "world"}) do
+      Log.fatal { {:hello => "world"} }
+    end
   end
 
   it "works with nil `message` within a NamedTuple" do
-    log.fatal { {hello: "world", message: nil} }
-    message, _, rest = output.to_s.chomp.partition(": ")
-    message.should eq ""
-    rest.should eq "hello=world"
+    expect_log_data("", {:hello => "world"}) do
+      Log.fatal { {hello: "world"} }
+    end
   end
 
   it "works with nil `message` within a Hash" do
-    log.fatal { {:hello => "world", :message => nil} }
-    message, _, rest = output.to_s.chomp.partition(": ")
-    message.should eq ""
-    rest.should eq "hello=world"
+    expect_log_data("", {:hello => "world"}) do
+      Log.fatal { {:hello => "world", :message => nil} }
+    end
   end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,2 +1,3 @@
 require "spec"
+require "log/spec"
 require "../src/log_helper"

--- a/src/log_helper.cr
+++ b/src/log_helper.cr
@@ -17,15 +17,16 @@ class Log
     previous_def(exception: exception) do |dsl|
       block_result = yield dsl
 
-      if block_result.is_a? Hash
+      case block_result
+      when Hash
         message = block_result.delete(:message) || block_result.delete("message")
         if message.nil?
           dsl.emit(data: block_result)
         else
           dsl.emit(message: message, data: block_result)
         end
-      elsif block_result.is_a? NamedTuple
-        if block_result.has_key?(:message) && block_result[:message]? == nil
+      when NamedTuple
+        if block_result.has_key?(:message) && block_result[:message]?.nil?
           # Special case as a `nil` message is interpreted as data in the spread
           block_result = block_result.to_h
           block_result.delete(:message)


### PR DESCRIPTION
Simplifies specs by using `Log::EntriesChecker`, also resolves an issue where log backends were not being registered.